### PR TITLE
Change liveness client

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ pub enum Error {
     Seeder(crate::client::liveness::seeder::SeederError),
     Profiler(crate::profiler::ProfilerError),
 
+    InitializeNewCluster(Box<dyn std::error::Error>),
     EmptyLeader,
     EmptyLeaderClusterRpcUrl,
     InvalidPlatformBlockHeight,

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ pub enum Error {
     Seeder(crate::client::liveness::seeder::SeederError),
     Profiler(crate::profiler::ProfilerError),
 
+    MerkleTreeDoesNotExist(String),
     InitializeNewCluster(Box<dyn std::error::Error>),
     EmptyLeader,
     EmptyLeaderClusterRpcUrl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod state;
 pub mod task;
 pub mod types;
 pub extern crate skde;
+pub mod merkle_tree_manager;
 pub mod util;

--- a/src/merkle_tree_manager.rs
+++ b/src/merkle_tree_manager.rs
@@ -1,0 +1,72 @@
+use std::{collections::HashMap, sync::Arc};
+
+use tokio::sync::Mutex;
+
+use crate::{error::Error, types::*};
+
+pub struct MerkleTreeManager {
+    inner: Arc<Mutex<HashMap<String, MerkleTree>>>,
+}
+
+impl Clone for MerkleTreeManager {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Default for MerkleTreeManager {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::default())),
+        }
+    }
+}
+
+impl MerkleTreeManager {
+    pub async fn init() -> Self {
+        let merkle_tree_manager = Self::default();
+
+        let rollup_id_list = RollupIdList::get_or(RollupIdList::default).unwrap();
+        for rollup_id in rollup_id_list.iter() {
+            let merkle_tree = MerkleTree::new();
+
+            if let Some(rollup_metadata) = RollupMetadata::get(rollup_id).ok() {
+                let transaction_order = rollup_metadata.transaction_order;
+                if transaction_order > 0 {
+                    for index in 1..rollup_metadata.transaction_order {
+                        let (raw_transaction, _) = RawTransactionModel::get(
+                            rollup_id,
+                            rollup_metadata.rollup_block_height,
+                            index,
+                        )
+                        .unwrap();
+                        merkle_tree
+                            .add_data(raw_transaction.raw_transaction_hash().as_ref())
+                            .await;
+                    }
+                }
+            }
+
+            println!("{:?}", merkle_tree.get_merkle_root().await);
+            merkle_tree_manager.insert(rollup_id, merkle_tree).await;
+        }
+
+        merkle_tree_manager
+    }
+
+    pub async fn insert(&self, rollup_id: &str, merkle_tree: MerkleTree) {
+        let mut lock = self.inner.lock().await;
+        lock.insert(rollup_id.to_owned(), merkle_tree);
+    }
+
+    pub async fn get(&self, rollup_id: &str) -> Result<MerkleTree, Error> {
+        let lock = self.inner.lock().await;
+        let merkle_tree = lock
+            .get(rollup_id)
+            .ok_or(Error::MerkleTreeDoesNotExist(rollup_id.to_owned()))?;
+
+        Ok(merkle_tree.clone())
+    }
+}

--- a/src/rpc/cluster/finalize_block.rs
+++ b/src/rpc/cluster/finalize_block.rs
@@ -157,12 +157,13 @@ impl RpcParameter<AppState> for FinalizeBlock {
             // Initialize new cluster if it doesn't exist
             initialize_new_cluster(
                 context.clone(),
-                &liveness_client,
+                liveness_client,
                 &rollup.cluster_id,
                 current_block_height,
                 block_margin,
             )
-            .await;
+            .await
+            .map_err(Error::InitializeNewCluster)?;
 
             // Try to fetch the cluster again after initialization
             context

--- a/src/rpc/cluster/sync_block.rs
+++ b/src/rpc/cluster/sync_block.rs
@@ -29,42 +29,21 @@ impl RpcParameter<AppState> for SyncBlock {
             self.transaction_count,
         );
 
-        let rollup = context
-            .get_rollup(&self.finalize_block_message.rollup_id)
-            .await?;
-
-        let cluster = context
-            .get_cluster(
-                rollup.platform,
-                rollup.service_provider,
-                &rollup.cluster_id,
-                self.finalize_block_message.platform_block_height,
-            )
-            .await?;
+        let rollup = Rollup::get(&self.finalize_block_message.rollup_id)?;
+        let cluster = Cluster::get(
+            rollup.platform,
+            rollup.service_provider,
+            &rollup.cluster_id,
+            self.finalize_block_message.platform_block_height,
+        )?;
 
         let next_rollup_block_height = self.finalize_block_message.rollup_block_height + 1;
         let signer = context.get_signer(rollup.platform).await.unwrap();
         let sequencer_address = signer.address().clone();
         let is_leader = sequencer_address == self.finalize_block_message.next_block_creator_address;
 
-        match context
-            .get_mut_rollup_metadata(&self.finalize_block_message.rollup_id)
-            .await
-        {
-            Ok(mut locked_rollup_metadata) => {
-                locked_rollup_metadata.rollup_block_height = next_rollup_block_height;
-                locked_rollup_metadata.new_merkle_tree();
-                locked_rollup_metadata.is_leader = is_leader;
-                locked_rollup_metadata.leader_sequencer_rpc_info = cluster
-                    .get_sequencer_rpc_info(&self.finalize_block_message.next_block_creator_address)
-                    .unwrap();
-                locked_rollup_metadata.platform_block_height =
-                    self.finalize_block_message.platform_block_height;
-            }
-            Err(_) => {
-                let mut rollup_metadata = RollupMetadata::default();
-
-                rollup_metadata.cluster_id = rollup.cluster_id;
+        match RollupMetadata::get_mut(&self.finalize_block_message.rollup_id) {
+            Ok(mut rollup_metadata) => {
                 rollup_metadata.rollup_block_height = next_rollup_block_height;
                 rollup_metadata.is_leader = is_leader;
                 rollup_metadata.leader_sequencer_rpc_info = cluster
@@ -72,14 +51,37 @@ impl RpcParameter<AppState> for SyncBlock {
                     .unwrap();
                 rollup_metadata.platform_block_height =
                     self.finalize_block_message.platform_block_height;
-                rollup_metadata.new_merkle_tree();
 
-                rollup_metadata.put(&self.finalize_block_message.rollup_id)?;
                 context
-                    .add_rollup_metadata(&self.finalize_block_message.rollup_id, rollup_metadata)
-                    .await?;
+                    .merkle_tree_manager()
+                    .insert(&self.finalize_block_message.rollup_id, MerkleTree::new())
+                    .await;
+                rollup_metadata.update()?;
             }
-        };
+            Err(error) => {
+                if error.is_none_type() {
+                    let mut rollup_metadata = RollupMetadata::default();
+                    rollup_metadata.cluster_id = rollup.cluster_id;
+                    rollup_metadata.rollup_block_height = next_rollup_block_height;
+                    rollup_metadata.is_leader = is_leader;
+                    rollup_metadata.leader_sequencer_rpc_info = cluster
+                        .get_sequencer_rpc_info(
+                            &self.finalize_block_message.next_block_creator_address,
+                        )
+                        .unwrap();
+                    rollup_metadata.platform_block_height =
+                        self.finalize_block_message.platform_block_height;
+
+                    context
+                        .merkle_tree_manager()
+                        .insert(&self.finalize_block_message.rollup_id, MerkleTree::new())
+                        .await;
+                    rollup_metadata.put(&self.finalize_block_message.rollup_id)?;
+                } else {
+                    return Err(error.into());
+                }
+            }
+        }
 
         follow_block(
             context.clone(),

--- a/src/rpc/cluster/sync_encrypted_transaction.rs
+++ b/src/rpc/cluster/sync_encrypted_transaction.rs
@@ -78,7 +78,7 @@ impl RpcParameter<AppState> for SyncEncryptedTransaction {
             .merkle_tree_manager()
             .get(&self.message.rollup_id)
             .await?;
-        merkle_tree.add_data(transaction_hash.as_ref());
+        merkle_tree.add_data(transaction_hash.as_ref()).await;
 
         Ok(())
     }

--- a/src/rpc/cluster/sync_raw_transaction.rs
+++ b/src/rpc/cluster/sync_raw_transaction.rs
@@ -32,17 +32,14 @@ impl RpcParameter<AppState> for SyncRawTransaction {
         //     self.message.order_commitment,
         // );
 
-        let rollup = context.get_rollup(&self.message.rollup_id).await?;
-        let rollup_metadata = context.get_rollup_metadata(&self.message.rollup_id).await?;
-
-        let cluster = context
-            .get_cluster(
-                rollup.platform,
-                rollup.service_provider,
-                &rollup.cluster_id,
-                rollup_metadata.platform_block_height,
-            )
-            .await?;
+        let rollup = Rollup::get(&self.message.rollup_id)?;
+        let mut rollup_metadata = RollupMetadata::get_mut(&self.message.rollup_id)?;
+        let cluster = Cluster::get(
+            rollup.platform,
+            rollup.service_provider,
+            &rollup.cluster_id,
+            rollup_metadata.platform_block_height,
+        )?;
 
         // Verify the leader signature
         let leader_address = cluster.get_leader_address(self.message.rollup_block_height)?;
@@ -52,15 +49,6 @@ impl RpcParameter<AppState> for SyncRawTransaction {
         // Check the rollup block height
         if self.message.rollup_block_height != rollup_metadata.rollup_block_height {
             return Err(Error::BlockHeightMismatch.into());
-        }
-
-        if self.message.transaction_order == rollup_metadata.transaction_order {
-            let mut locked_rollup_metadata = context
-                .get_mut_rollup_metadata(&self.message.rollup_id)
-                .await?;
-            locked_rollup_metadata
-                .add_transaction_hash(self.message.raw_transaction.raw_transaction_hash().as_ref());
-            drop(locked_rollup_metadata);
         }
 
         let transaction_hash = self.message.raw_transaction.raw_transaction_hash();
@@ -87,6 +75,15 @@ impl RpcParameter<AppState> for SyncRawTransaction {
                 self.message.transaction_order,
             )?;
         }
+
+        rollup_metadata.transaction_order += 1;
+        rollup_metadata.update()?;
+
+        let merkle_tree = context
+            .merkle_tree_manager()
+            .get(&self.message.rollup_id)
+            .await?;
+        merkle_tree.add_data(transaction_hash.as_ref());
 
         Ok(())
     }

--- a/src/rpc/cluster/sync_raw_transaction.rs
+++ b/src/rpc/cluster/sync_raw_transaction.rs
@@ -83,7 +83,7 @@ impl RpcParameter<AppState> for SyncRawTransaction {
             .merkle_tree_manager()
             .get(&self.message.rollup_id)
             .await?;
-        merkle_tree.add_data(transaction_hash.as_ref());
+        merkle_tree.add_data(transaction_hash.as_ref()).await;
 
         Ok(())
     }

--- a/src/rpc/external/get_rollup.rs
+++ b/src/rpc/external/get_rollup.rs
@@ -17,8 +17,8 @@ impl RpcParameter<AppState> for GetRollup {
         "get_rollup"
     }
 
-    async fn handler(self, context: AppState) -> Result<Self::Response, RpcError> {
-        let rollup = context.get_rollup(&self.rollup_id).await?;
+    async fn handler(self, _context: AppState) -> Result<Self::Response, RpcError> {
+        let rollup = Rollup::get(&self.rollup_id)?;
 
         Ok(GetRollupResponse { rollup })
     }

--- a/src/rpc/external/get_rollup_metadata.rs
+++ b/src/rpc/external/get_rollup_metadata.rs
@@ -17,8 +17,8 @@ impl RpcParameter<AppState> for GetRollupMetadata {
         "get_rollup_metadata"
     }
 
-    async fn handler(self, context: AppState) -> Result<Self::Response, RpcError> {
-        let rollup_metadata = context.get_rollup_metadata(&self.rollup_id).await?;
+    async fn handler(self, _context: AppState) -> Result<Self::Response, RpcError> {
+        let rollup_metadata = RollupMetadata::get(&self.rollup_id)?;
 
         Ok(GetRollupMetadataResponse { rollup_metadata })
     }

--- a/src/rpc/internal/get_cluster.rs
+++ b/src/rpc/internal/get_cluster.rs
@@ -45,14 +45,12 @@ impl RpcParameter<AppState> for GetCluster {
                         block_height
                     };
 
-                let cluster = context
-                    .get_cluster(
-                        self.platform,
-                        self.service_provider,
-                        &self.cluster_id,
-                        platform_block_height,
-                    )
-                    .await?;
+                let cluster = Cluster::get(
+                    self.platform,
+                    self.service_provider,
+                    &self.cluster_id,
+                    platform_block_height,
+                )?;
 
                 Ok(GetClusterResponse { cluster })
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use std::{any::Any, sync::Arc};
 
 use radius_sdk::{
     json_rpc::client::RpcClient,
-    kvstore::{CachedKvStore, CachedKvStoreError, Value},
+    kvstore::{CachedKvStore, CachedKvStoreError},
     signature::PrivateKeySigner,
 };
 use skde::delay_encryption::SkdeParams;
@@ -11,7 +11,7 @@ use crate::{
     client::liveness::{
         distributed_key_generation::DistributedKeyGenerationClient, seeder::SeederClient,
     },
-    error::Error,
+    merkle_tree_manager::MerkleTreeManager,
     profiler::Profiler,
     types::*,
 };
@@ -24,20 +24,13 @@ struct AppStateInner {
     config: Config,
     seeder_client: SeederClient,
     distributed_key_generation_client: DistributedKeyGenerationClient,
-
     liveness_clients: CachedKvStore,
     validation_clients: CachedKvStore,
     signers: CachedKvStore,
-
     skde_params: SkdeParams,
-
     profiler: Option<Profiler>,
-
-    clusters: CachedKvStore,
-    rollups: CachedKvStore,
-    rollup_metadatas: CachedKvStore,
-
     rpc_client: RpcClient,
+    merkle_tree_manager: MerkleTreeManager,
 }
 
 impl Clone for AppState {
@@ -59,10 +52,8 @@ impl AppState {
         validation_clients: CachedKvStore,
         skde_params: SkdeParams,
         profiler: Option<Profiler>,
-        rollup_metadatas: CachedKvStore,
-        rollups: CachedKvStore,
-        clusters: CachedKvStore,
         rpc_client: RpcClient,
+        merkle_tree_manager: MerkleTreeManager,
     ) -> Self {
         let inner = AppStateInner {
             config,
@@ -73,10 +64,8 @@ impl AppState {
             validation_clients,
             skde_params,
             profiler,
-            rollup_metadatas,
-            rollups,
-            clusters,
             rpc_client,
+            merkle_tree_manager,
         };
 
         Self {
@@ -107,248 +96,9 @@ impl AppState {
     pub fn rpc_client(&self) -> &RpcClient {
         &self.inner.rpc_client
     }
-}
 
-/// Rollup metadata functions
-impl AppState {
-    pub async fn add_rollup_metadata(
-        &self,
-        rollup_id: &str,
-        rollup_metadata: RollupMetadata,
-    ) -> Result<(), Error> {
-        self.inner
-            .rollup_metadatas
-            .put(&rollup_id, rollup_metadata)
-            .await
-            .map_err(Error::CachedKvStore)?;
-
-        Ok(())
-    }
-
-    pub async fn get_rollup_metadata(&self, rollup_id: &str) -> Result<RollupMetadata, Error> {
-        match self.inner.rollup_metadatas.get(&rollup_id).await {
-            Ok(rollup_metadata) => Ok(rollup_metadata),
-            Err(_) => {
-                tracing::warn!(
-                    "RollupMetadata not found in cache - rollup_id: {}",
-                    rollup_id
-                );
-
-                let rollup_metadata = RollupMetadata::get(rollup_id).map_err(Error::Database)?;
-
-                self.add_rollup_metadata(rollup_id, rollup_metadata.clone())
-                    .await?;
-
-                Ok(rollup_metadata)
-            }
-        }
-    }
-
-    pub async fn get_mut_rollup_metadata(
-        &self,
-        rollup_id: &str,
-    ) -> Result<Value<RollupMetadata>, Error> {
-        match self.inner.rollup_metadatas.get_mut(&rollup_id).await {
-            Ok(rollup_metadata) => Ok(rollup_metadata),
-            Err(_) => {
-                let rollup_metadata = RollupMetadata::get(rollup_id).map_err(Error::Database)?;
-
-                self.add_rollup_metadata(rollup_id, rollup_metadata.clone())
-                    .await?;
-
-                self.inner
-                    .rollup_metadatas
-                    .get_mut(&rollup_id)
-                    .await
-                    .map_err(Error::CachedKvStore)
-            }
-        }
-    }
-}
-
-/// Cluster functions
-impl AppState {
-    pub async fn add_cluster(
-        &self,
-        platform: Platform,
-        service_provider: ServiceProvider,
-        cluster_id: &str,
-        platform_block_height: u64,
-        cluster: Cluster,
-    ) -> Result<(), Error> {
-        let key = &(
-            platform,
-            service_provider,
-            cluster_id,
-            platform_block_height,
-        );
-
-        self.inner
-            .clusters
-            .put(key, cluster)
-            .await
-            .map_err(Error::CachedKvStore)?;
-
-        Ok(())
-    }
-
-    pub async fn delete_cluster(
-        &self,
-        platform: Platform,
-        service_provider: ServiceProvider,
-        cluster_id: &str,
-        platform_block_height: u64,
-    ) -> Result<(), Error> {
-        let key = &(
-            platform,
-            service_provider,
-            cluster_id,
-            platform_block_height,
-        );
-
-        self.inner
-            .clusters
-            .delete::<(Platform, ServiceProvider, &str, u64), Cluster>(key)
-            .await
-            .map_err(Error::CachedKvStore)?;
-
-        Ok(())
-    }
-
-    pub async fn get_cluster(
-        &self,
-        platform: Platform,
-        service_provider: ServiceProvider,
-        cluster_id: &str,
-        platform_block_height: u64,
-    ) -> Result<Cluster, Error> {
-        let key = &(
-            platform,
-            service_provider,
-            cluster_id,
-            platform_block_height,
-        );
-
-        match self.inner.clusters.get(key).await {
-            Ok(cluster) => Ok(cluster),
-            Err(_) => {
-                tracing::warn!(
-                    "Cluster not found in cache - platform block_height: {}",
-                    platform_block_height
-                );
-
-                let cluster = Cluster::get(
-                    platform,
-                    service_provider,
-                    cluster_id,
-                    platform_block_height,
-                )
-                .map_err(Error::Database)?;
-
-                self.add_cluster(
-                    platform,
-                    service_provider,
-                    cluster_id,
-                    platform_block_height,
-                    cluster.clone(),
-                )
-                .await?;
-
-                Ok(cluster)
-            }
-        }
-    }
-
-    pub async fn get_mut_cluster(
-        &self,
-        platform: Platform,
-        service_provider: ServiceProvider,
-        cluster_id: &str,
-        platform_block_height: u64,
-    ) -> Result<Value<Cluster>, Error> {
-        let key = &(
-            platform,
-            service_provider,
-            cluster_id,
-            platform_block_height,
-        );
-
-        match self.inner.clusters.get_mut(key).await {
-            Ok(rollup_metadata) => Ok(rollup_metadata),
-            Err(_) => {
-                let cluster = Cluster::get(
-                    platform,
-                    service_provider,
-                    cluster_id,
-                    platform_block_height,
-                )
-                .map_err(Error::Database)?;
-
-                self.add_cluster(
-                    platform,
-                    service_provider,
-                    cluster_id,
-                    platform_block_height,
-                    cluster.clone(),
-                )
-                .await?;
-
-                self.inner
-                    .clusters
-                    .get_mut(key)
-                    .await
-                    .map_err(Error::CachedKvStore)
-            }
-        }
-    }
-}
-
-/// Rollup functions
-impl AppState {
-    pub async fn add_rollup(&self, rollup_id: &str, rollup: Rollup) -> Result<(), Error> {
-        let key = &(rollup_id);
-
-        self.inner
-            .rollups
-            .put(key, rollup)
-            .await
-            .map_err(Error::CachedKvStore)?;
-
-        Ok(())
-    }
-
-    pub async fn get_rollup(&self, rollup_id: &str) -> Result<Rollup, Error> {
-        let key = &(rollup_id);
-
-        match self.inner.rollups.get(key).await {
-            Ok(rollup) => Ok(rollup),
-            Err(_) => {
-                tracing::warn!("Rollup not found in cache - rollup_id: {}", rollup_id);
-
-                let rollup = Rollup::get(rollup_id).map_err(Error::Database)?;
-
-                self.add_rollup(rollup_id, rollup.clone()).await?;
-
-                Ok(rollup)
-            }
-        }
-    }
-
-    pub async fn get_mut_rollup(&self, rollup_id: &str) -> Result<Value<Rollup>, Error> {
-        match self.inner.rollups.get_mut(&rollup_id).await {
-            Ok(rollup) => Ok(rollup),
-            Err(_) => {
-                let rollup = Rollup::get(rollup_id).map_err(Error::Database)?;
-
-                self.add_rollup(rollup_id, rollup.clone()).await?;
-
-                self.inner
-                    .rollups
-                    .get_mut(&rollup_id)
-                    .await
-                    .map_err(Error::CachedKvStore)
-            }
-        }
+    pub fn merkle_tree_manager(&self) -> &MerkleTreeManager {
+        &self.inner.merkle_tree_manager
     }
 }
 

--- a/src/task/block_builder/mod.rs
+++ b/src/task/block_builder/mod.rs
@@ -61,10 +61,7 @@ pub fn build_block(
             EncryptedTransactionType::NotSupport => unimplemented!(),
         };
 
-        let rollup: Rollup = context
-            .get_rollup(&finalize_block_message.rollup_id)
-            .await
-            .unwrap();
+        let rollup = Rollup::get(&finalize_block_message.rollup_id).unwrap();
 
         let validation_platform = rollup.validation_info.platform.clone();
         let validation_service_provider =

--- a/src/types/cluster.rs
+++ b/src/types/cluster.rs
@@ -214,6 +214,16 @@ impl ClusterIdList {
 #[kvstore(key(platform: Platform, service_provider: ServiceProvider, cluster_id: &str))]
 pub struct LatestClusterBlockHeight(u64);
 
+impl LatestClusterBlockHeight {
+    pub fn get_block_height(&self) -> u64 {
+        self.0
+    }
+
+    pub fn set_block_height(&mut self, block_height: u64) {
+        self.0 = block_height;
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Model)]
 #[kvstore(key(cluster_id: &str, platform_block_height: u64))]
 pub struct LivenessEventList(Vec<LivenessEventType>);

--- a/src/types/cluster.rs
+++ b/src/types/cluster.rs
@@ -4,7 +4,7 @@ use std::collections::{
 };
 
 use super::prelude::*;
-use crate::{client::liveness::seeder::SequencerRpcInfo, error::Error, state::AppState};
+use crate::{client::liveness::seeder::SequencerRpcInfo, error::Error};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Model)]
 #[kvstore(key(platform: Platform, service_provider: ServiceProvider, cluster_id: &str, platform_block_height: u64))]
@@ -34,7 +34,6 @@ impl Cluster {
     }
 
     pub async fn put_and_update_with_margin(
-        context: AppState,
         cluster: &Cluster,
         platform: Platform,
         service_provider: ServiceProvider,
@@ -58,25 +57,6 @@ impl Cluster {
             cluster_id,
             block_height_for_remove,
         )?;
-
-        let _ = context
-            .add_cluster(
-                platform,
-                service_provider,
-                cluster_id,
-                platform_block_height,
-                cluster.clone(),
-            )
-            .await;
-
-        let _ = context
-            .delete_cluster(
-                platform,
-                service_provider,
-                cluster_id,
-                block_height_for_remove,
-            )
-            .await;
 
         Ok(())
     }

--- a/src/types/merkle.rs
+++ b/src/types/merkle.rs
@@ -1,102 +1,106 @@
-use serde::{Deserialize, Serialize};
-use sha3::{Digest, Keccak256};
+use std::sync::Arc;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+use sha3::{Digest, Keccak256};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Default)]
 pub struct MerkleTree {
-    pub nodes: Vec<Vec<[u8; 32]>>, // nodes by tree level
+    pub nodes: Arc<Mutex<Vec<Vec<[u8; 32]>>>>, // nodes by tree level
 }
 
 impl MerkleTree {
     pub fn new() -> Self {
         Self {
-            nodes: vec![vec![]],
+            nodes: Arc::new(Mutex::new(vec![vec![]])),
         }
     }
 
-    fn update_tree(&mut self) {
+    fn update_tree(nodes: &mut Vec<Vec<[u8; 32]>>) {
         let mut current_level = 0;
 
-        if self.nodes[current_level].is_empty() {
+        if nodes[current_level].is_empty() {
             return;
         }
 
-        while self.nodes[current_level].len() % 2 == 0 {
-            let level = &self.nodes[current_level];
+        while nodes[current_level].len() % 2 == 0 {
+            let level = &nodes[current_level];
             let right_node = &level[level.len() - 1];
             let left_node = &level[level.len() - 2];
 
             let parent_node = Self::hash(&Self::concat_arrays(*left_node, *right_node));
 
-            if self.nodes.len() <= current_level + 1 {
-                self.nodes.push(vec![parent_node]);
+            if nodes.len() <= current_level + 1 {
+                nodes.push(vec![parent_node]);
             } else {
-                self.nodes[current_level + 1].push(parent_node);
+                nodes[current_level + 1].push(parent_node);
             }
 
             current_level += 1;
         }
     }
 
-    pub fn finalize_tree(&mut self) {
-        let last_node = self.nodes[0].last().cloned().unwrap_or_default();
+    pub async fn finalize_tree(&self) {
+        let mut nodes = self.nodes.lock().await;
+        let last_node = nodes[0].last().cloned().unwrap_or_default();
         let mut current_level = 0;
 
-        while self.nodes[current_level].len() > 1 {
-            if self.nodes[current_level].len() % 2 == 1 {
-                let left_node = self.nodes[current_level].last().unwrap();
+        while nodes[current_level].len() > 1 {
+            if nodes[current_level].len() % 2 == 1 {
+                let left_node = nodes[current_level].last().unwrap();
                 let parent_node = Self::hash(&Self::concat_arrays(*left_node, last_node));
 
-                self.nodes[current_level].push(last_node);
-                self.nodes[current_level + 1].push(parent_node);
+                nodes[current_level].push(last_node);
+                nodes[current_level + 1].push(parent_node);
             }
 
-            if self.nodes.len() <= current_level + 1 {
-                let left_node = self.nodes[current_level][0];
-                let right_node = self.nodes[current_level][1];
+            if nodes.len() <= current_level + 1 {
+                let left_node = nodes[current_level][0];
+                let right_node = nodes[current_level][1];
 
                 let merkle_root = Self::hash(&Self::concat_arrays(left_node, right_node));
-                self.nodes.push(vec![merkle_root]);
+                nodes.push(vec![merkle_root]);
             }
 
             current_level += 1;
         }
     }
 
-    pub fn add_data(&mut self, data: &str) -> (u64, Vec<[u8; 32]>) {
-        self.update_tree();
+    pub async fn add_data(&self, data: &str) -> (u64, Vec<[u8; 32]>) {
+        let mut nodes = self.nodes.lock().await;
+        Self::update_tree(&mut nodes);
 
-        let pre_merkle_path = self.get_pre_merkle_path();
+        let pre_merkle_path = Self::get_pre_merkle_path(&nodes);
 
         let hashed_data = Self::hash(data.as_bytes());
-        self.nodes[0].push(hashed_data);
+        nodes[0].push(hashed_data);
 
-        ((self.nodes[0].len() - 1) as u64, pre_merkle_path)
+        ((nodes[0].len() - 1) as u64, pre_merkle_path)
     }
 
-    fn get_pre_merkle_path(&self) -> Vec<[u8; 32]> {
+    fn get_pre_merkle_path(nodes: &Vec<Vec<[u8; 32]>>) -> Vec<[u8; 32]> {
         let mut proof = vec![];
         let mut leaf_node_index: usize = 0;
 
-        let leaf_node_count = self.nodes[0].len();
+        let leaf_node_count = nodes[0].len();
 
         if leaf_node_count == 0 {
             return proof;
         }
 
         if leaf_node_count == 1 {
-            return vec![self.nodes[0][0]];
+            return vec![nodes[0][0]];
         }
 
         loop {
             let mut current_level = 0;
             let mut target_index = leaf_node_index;
 
-            while self.nodes[current_level].len() > target_index + 1 {
+            while nodes[current_level].len() > target_index + 1 {
                 current_level += 1;
                 target_index /= 2;
             }
 
-            proof.push(self.nodes[current_level][target_index]);
+            proof.push(nodes[current_level][target_index]);
 
             leaf_node_index += 2_usize.pow(current_level as u32);
 
@@ -108,11 +112,12 @@ impl MerkleTree {
         proof
     }
 
-    pub fn get_merkle_path(&self, index: usize) -> Vec<[u8; 32]> {
+    pub async fn get_merkle_path(&self, index: usize) -> Vec<[u8; 32]> {
+        let nodes = self.nodes.lock().await;
         let mut path = vec![];
         let mut current_index = index;
 
-        for level in &self.nodes {
+        for level in nodes.iter() {
             if level.len() <= 1 {
                 break;
             }
@@ -133,19 +138,17 @@ impl MerkleTree {
         path
     }
 
-    pub fn get_merkle_root(&self) -> [u8; 32] {
-        if self.nodes[0].is_empty() {
+    pub async fn get_merkle_root(&self) -> [u8; 32] {
+        let nodes = self.nodes.lock().await;
+        if nodes[0].is_empty() {
             return Self::hash(b"");
         }
-        self.nodes
+
+        nodes
             .last()
             .and_then(|level| level.get(0).cloned())
             .unwrap()
     }
-
-    // fn to_bytes32(data: &str) -> [u8; 32] {
-    //     const_hex::decode_to_array(data).unwrap()
-    // }
 
     pub fn hash(data: &[u8]) -> [u8; 32] {
         let mut hasher = Keccak256::new();
@@ -156,10 +159,11 @@ impl MerkleTree {
         hash
     }
 
-    pub fn get_post_merkle_path(&self, mut index: usize) -> Vec<[u8; 32]> {
+    pub async fn get_post_merkle_path(&self, mut index: usize) -> Vec<[u8; 32]> {
+        let nodes = self.nodes.lock().await;
         let mut post_merkle_path = Vec::new();
 
-        for level in self.nodes.iter().take(self.nodes.len() - 1) {
+        for level in nodes.iter().take(nodes.len() - 1) {
             if index % 2 == 0 && index + 1 < level.len() {
                 post_merkle_path.push(level[index + 1]);
             }
@@ -177,55 +181,4 @@ impl MerkleTree {
         }
         array
     }
-}
-
-#[test]
-fn block_commitment_test() {
-    let mut merkle_tree = MerkleTree::new();
-
-    let data = "Example data";
-
-    let check_index = 3;
-    let mut check_pre_merkle_path = Vec::new();
-    let mut check_post_merkle_path = Vec::new();
-    loop {
-        let (index, pre_merkle_path) = merkle_tree.add_data(data);
-        println!("Transaction Index: {}", index);
-        println!("Nodes: {:?}", merkle_tree.nodes);
-        println!("pre_merkle_path: {:?}", pre_merkle_path);
-        println!("");
-
-        if index == check_index {
-            check_pre_merkle_path = pre_merkle_path;
-        }
-        if index >= 7 {
-            break;
-        }
-    }
-
-    merkle_tree.finalize_tree();
-    println!("Nodes: {:?}", merkle_tree.nodes);
-    println!("");
-
-    let merkle_root = merkle_tree.get_merkle_root();
-    println!("Merkle root: {:?}", merkle_root);
-    println!("");
-
-    let mut index = 0;
-    loop {
-        let post_merke_path = merkle_tree.get_post_merkle_path(index);
-
-        if index == check_index as usize {
-            check_post_merkle_path = post_merke_path;
-        }
-        if index >= 7 {
-            break;
-        }
-        index += 1;
-    }
-
-    let merged_merkle_path: Vec<[u8; 32]> =
-        [check_pre_merkle_path, check_post_merkle_path].concat();
-
-    println!("Merged Merkle Path: {:?}", merged_merkle_path);
 }

--- a/src/types/rollup/rollup_metadata.rs
+++ b/src/types/rollup/rollup_metadata.rs
@@ -1,7 +1,6 @@
 use radius_sdk::kvstore::Model;
 use serde::{Deserialize, Serialize};
 
-use super::MerkleTree;
 use crate::client::liveness::seeder::SequencerRpcInfo;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Model)]
@@ -9,24 +8,8 @@ use crate::client::liveness::seeder::SequencerRpcInfo;
 pub struct RollupMetadata {
     pub rollup_block_height: u64,
     pub transaction_order: u64,
-
-    pub merkle_tree: MerkleTree,
-
     pub cluster_id: String,
-
     pub platform_block_height: u64,
     pub is_leader: bool,
     pub leader_sequencer_rpc_info: SequencerRpcInfo,
-}
-
-impl RollupMetadata {
-    pub fn new_merkle_tree(&mut self) {
-        self.transaction_order = 0;
-        self.merkle_tree = MerkleTree::new();
-    }
-
-    pub fn add_transaction_hash(&mut self, transaction_hash: &str) -> (u64, Vec<[u8; 32]>) {
-        self.transaction_order += 1;
-        self.merkle_tree.add_data(transaction_hash)
-    }
 }


### PR DESCRIPTION
# Changelog:
- Change `LivenessClient` to fetch cluster information every block (the old way).
- Add `MerkleTreeManager`.
- Change `MerkleTree`.
- Fetch `Rollup`, `RollupMetadata` and `Cluster` from `KvStore` (the old way).